### PR TITLE
fix issue 86 - uploaded docs should not be in payload on update claims

### DIFF
--- a/app/newClaim/[id]/page.tsx
+++ b/app/newClaim/[id]/page.tsx
@@ -80,17 +80,24 @@ export default function EditClaimForm() {
         if (Array.isArray(OTHER)) {
           OTHER.forEach(removeKeys);
         }
+        const isNewUpload = (doc: any) => doc && !!doc.isNew;
+
         const payload = {
           ...others,
           status: value ? value : undefined,
-          documents: [
-            CLINIC_PAPER,
-            ICP,
-            PAST_INVESTIGATION,
-            CURRENT_INVESTIGATION,
-            ...(OTHER || []), 
-          ].filter(Boolean),
-          isBasicClaimUpdate: isClaimAssigned
+          isBasicClaimUpdate: isClaimAssigned,
+          ...((() => {
+            const changed = [
+              isNewUpload(CLINIC_PAPER) ? CLINIC_PAPER : null,
+              isNewUpload(ICP) ? ICP : null,
+              isNewUpload(PAST_INVESTIGATION) ? PAST_INVESTIGATION : null,
+              isNewUpload(CURRENT_INVESTIGATION) ? CURRENT_INVESTIGATION : null,
+              ...(Array.isArray(OTHER) ? OTHER.filter(isNewUpload) : []),
+            ].filter(Boolean)
+              .map(({ url, file, isNew, ...rest }) => rest);
+
+            return changed.length > 0 ? { documents: changed } : {};
+          })()),
         };
         setLoading(true);
         const res = await updateClaims(payload, id);

--- a/components/CreateClaim.tsx
+++ b/components/CreateClaim.tsx
@@ -134,6 +134,7 @@ export default function CreateClaim({
         const uploadedFiles = res?.data?.map((file) => ({
           fileName: file?.key,
           type: name,
+          isNew: true,
           ...(name === "OTHER" && { remark: "custom remark" }),
         }));
 
@@ -182,6 +183,7 @@ export default function CreateClaim({
             fileName: res?.data?.key,
             type: name,
             file: value[0],
+            isNew: true,
             ...(name === "OTHER" && { remark: "custom remark" }),
           },
         }));


### PR DESCRIPTION
fixes #86 - uploaded docs should not be in payload on update claims.

Problem
1)When editing a claim, all documents were being sent to backend on every save.
2)This happened even if the user didn't change anything.

Fix
1)Added isNew: true flag when user uploads a new file.
2)Only docs with isNew: true are sent in the payload.
3)isNew, file, and url are stripped before sending to backend.
4)If nothing changed, documents key is skipped entirely.
